### PR TITLE
Fix Infinite Loading Spinner on API Errors

### DIFF
--- a/manipulacao_de_dados_codigo_base.ipynb
+++ b/manipulacao_de_dados_codigo_base.ipynb
@@ -2656,7 +2656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "necessary-absolute",
+   "id": "necessary-absolute", S0Xvh6ZZaQ
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Resolved a bug causing the loading spinner to remain on API failure.